### PR TITLE
Enable betaV2 for HPA

### DIFF
--- a/dind/templates/hpa.yaml
+++ b/dind/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.22.0-0" $kubeTargetVersion -}}
+apiVersion: autoscaling/v2beta2
+{{- else }}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dind.fullname" . }}

--- a/dind/templates/hpa.yaml
+++ b/dind/templates/hpa.yaml
@@ -1,5 +1,7 @@
+{{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+
 {{- if .Values.autoscaling.enabled }}
-{{- if semverCompare ">=1.22.0-0" $kubeTargetVersion }}
+{{- if semverCompare ">=1.22.0-0" $kubeVersion }}
 apiVersion: autoscaling/v2beta2
 {{- else }}
 apiVersion: autoscaling/v2beta1

--- a/dind/templates/hpa.yaml
+++ b/dind/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if semverCompare ">=1.22.0-0" $kubeTargetVersion -}}
+{{- if semverCompare ">=1.22.0-0" $kubeTargetVersion }}
 apiVersion: autoscaling/v2beta2
 {{- else }}
 apiVersion: autoscaling/v2beta1

--- a/dind/templates/hpa.yaml
+++ b/dind/templates/hpa.yaml
@@ -24,11 +24,11 @@ spec:
       resource:
         name: cpu
         {{- if semverCompare ">=1.22.0-0" $kubeVersion }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
         {{- end }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
@@ -36,11 +36,11 @@ spec:
       resource:
         name: memory
         {{- if semverCompare ">=1.22.0-0" $kubeVersion }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/dind/templates/hpa.yaml
+++ b/dind/templates/hpa.yaml
@@ -23,12 +23,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.22.0-0" $kubeVersion }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.22.0-0" $kubeVersion }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler