### PR TITLE
update hpa for k8s compatibility

### DIFF
--- a/dind/templates/hpa.yaml
+++ b/dind/templates/hpa.yaml
@@ -1,5 +1,11 @@
+{{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.22.0-0" $kubeVersion }}
+apiVersion: autoscaling/v2beta2
+{{- else }}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dind.fullname" . }}
@@ -17,12 +23,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.22.0-0" $kubeVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.22.0-0" $kubeVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler